### PR TITLE
Updates for Summer 16 MC and 2016 legacy re-reco

### DIFF
--- a/MonoXAnalysis/cfg/run_wmass_cfg.py
+++ b/MonoXAnalysis/cfg/run_wmass_cfg.py
@@ -470,6 +470,18 @@ elif test == '80X-MC':
         comp.files = [ tmpfil ]
         comp.splitFactor = 1
         if not getHeppyOption("single"): comp.fineSplitFactor = 4
+    if what == "WJets":
+        WJetsToLNu = kreator.makeMCComponent("WJetsToLNu", "/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM", "CMS", ".*root", 3* 20508.9)
+        selectedComponents = [ WJetsToLNu ]
+        comp = selectedComponents[0]
+        comp.triggers = []
+        comp.files = [ '/store/mc/RunIISummer16MiniAODv2/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/160DFF65-E8BF-E611-A4AD-0CC47AC08C1A.root' ]
+        tmpfil = os.path.expandvars("/tmp/$USER/160DFF65-E8BF-E611-A4AD-0CC47AC08C1A.root")
+        if not os.path.exists(tmpfil):
+            os.system("xrdcp root://eoscms//eos/cms%s %s" % (comp.files[0],tmpfil))
+        comp.files = [ tmpfil ]
+        comp.splitFactor = 1
+        if not getHeppyOption("single"): comp.fineSplitFactor = 4
     else: raise RuntimeError, "Unknown MC sample: %s" % what
 elif test == '80X-Data':
     DoubleMuon = kreator.makeDataComponent("DoubleMuon_Run2016B_run274315", "/DoubleMuon/Run2016B-18Apr2017_ver2-v1/MINIAOD", "CMS", ".*root", run_range = (274315,274315), triggers = triggers_mumu)

--- a/MonoXAnalysis/cfg/run_wmass_cfg.py
+++ b/MonoXAnalysis/cfg/run_wmass_cfg.py
@@ -7,14 +7,13 @@ import re
 
 #-------- LOAD ALL ANALYZERS -----------
 
-from CMGTools.TTHAnalysis.analyzers.susyCore_modules_cff import *
+from CMGTools.MonoXAnalysis.analyzers.dmCore_modules_cff import *
 from PhysicsTools.HeppyCore.framework.heppy_loop import getHeppyOption
 
 #-------- SET OPTIONS AND REDEFINE CONFIGURATIONS -----------
 
-runData = getHeppyOption("runData",True)
+runData = getHeppyOption("runData",False)
 runDataQCD = getHeppyOption("runDataQCD",False)
-runQCDBM = getHeppyOption("runQCDBM",False)
 runFRMC = getHeppyOption("runFRMC",False)
 scaleProdToLumi = float(getHeppyOption("scaleProdToLumi",-1)) # produce rough equivalent of X /pb for MC datasets
 removeJetReCalibration = getHeppyOption("removeJetReCalibration",False)
@@ -42,8 +41,8 @@ lepAna.miniIsolationVetoLeptons = None # use 'inclusive' to veto inclusive lepto
 lepAna.doIsolationScan = False
 
 # Lepton Preselection
-lepAna.loose_electron_id = "POG_MVA_ID_Spring15_NonTrig_VLooseIdEmu"
-isolation = "miniIso"
+lepAna.loose_electron_id = "POG_Cuts_ID_SPRING16_25ns_v1_HLT"
+isolation = None
 
 jetAna.lepSelCut = lambda lep : False # no cleaning of jets with leptons
 jetAnaScaleDown.lepSelCut = lambda lep : False # no cleaning of jets with leptons
@@ -60,10 +59,10 @@ if not removeJecUncertainty:
     jetAnaScaleUp.copyJetsByValue = True # do not remove this
     jetAnaScaleUp.doQG = False
     metAnaScaleUp.copyMETsByValue = True # do not remove this
-    susyCoreSequence.insert(susyCoreSequence.index(jetAna)+1, jetAnaScaleDown)
-    susyCoreSequence.insert(susyCoreSequence.index(jetAna)+1, jetAnaScaleUp)
-    susyCoreSequence.insert(susyCoreSequence.index(metAna)+1, metAnaScaleDown)
-    susyCoreSequence.insert(susyCoreSequence.index(metAna)+1, metAnaScaleUp)
+    dmCoreSequence.insert(dmCoreSequence.index(jetAna)+1, jetAnaScaleDown)
+    dmCoreSequence.insert(dmCoreSequence.index(jetAna)+1, jetAnaScaleUp)
+    dmCoreSequence.insert(dmCoreSequence.index(metAna)+1, metAnaScaleDown)
+    dmCoreSequence.insert(dmCoreSequence.index(metAna)+1, metAnaScaleUp)
 
 
 if isolation == "miniIso": 
@@ -113,10 +112,7 @@ if doPhotonCorr:
 photonAna.do_mc_match = False
 
 # switch off un-needed analyzers
-susyCoreSequence.remove(tauAna)
-susyCoreSequence.remove(genHiggsAna)
-susyCoreSequence.remove(susyScanAna)
-susyCoreSequence.remove(isoTrackAna)
+dmCoreSequence.remove(photonAna)
 
 #-------- ADDITIONAL ANALYZERS -----------
 
@@ -127,20 +123,7 @@ ttHEventAna = cfg.Analyzer(
     minJets25 = 0,
     )
 
-## JetTau analyzer, to be called (for the moment) once bjetsMedium are produced
-from CMGTools.TTHAnalysis.analyzers.ttHJetTauAnalyzer import ttHJetTauAnalyzer
-ttHJetTauAna = cfg.Analyzer(
-    ttHJetTauAnalyzer, name="ttHJetTauAnalyzer",
-    )
-
-## Insert the SV analyzer in the sequence
-susyCoreSequence.insert(susyCoreSequence.index(ttHCoreEventAna), 
-                        ttHSVAna)
-ttHSVAna.preselection = lambda ivf : abs(ivf.dxy.value())<2 and ivf.cosTheta>0.98
-
-
 from CMGTools.MonoXAnalysis.analyzers.treeProducerWMass import * 
-del wmass_collections['generatorSummary']
 
 # Spring16 electron MVA - follow instructions on pull request for correct area setup
 leptonTypeSusy.addVariables([
@@ -168,16 +151,15 @@ treeProducer = cfg.Analyzer(
 
 
 ## histo counter
-susyCoreSequence.insert(susyCoreSequence.index(skimAnalyzer),
-                        susyCounter)
-susyScanAna.doLHE=False # until a proper fix is put in the analyzer
+dmCoreSequence.insert(dmCoreSequence.index(skimAnalyzer),
+                        histoCounter)
 
 # HBHE new filter
 from CMGTools.TTHAnalysis.analyzers.hbheAnalyzer import hbheAnalyzer
 hbheAna = cfg.Analyzer(
     hbheAnalyzer, name="hbheAnalyzer", IgnoreTS4TS5ifJetInLowBVRegion=False
     )
-susyCoreSequence.insert(susyCoreSequence.index(ttHCoreEventAna),hbheAna)
+dmCoreSequence.insert(dmCoreSequence.index(ttHCoreEventAna),hbheAna)
 treeProducer.globalVariables.append(NTupleVariable("hbheFilterNew50ns", lambda ev: ev.hbheFilterNew50ns, int, help="new HBHE filter for 50 ns"))
 treeProducer.globalVariables.append(NTupleVariable("hbheFilterNew25ns", lambda ev: ev.hbheFilterNew25ns, int, help="new HBHE filter for 25 ns"))
 treeProducer.globalVariables.append(NTupleVariable("hbheFilterIso", lambda ev: ev.hbheFilterIso, int, help="HBHE iso-based noise filter"))
@@ -218,22 +200,24 @@ triggerFlagsAna.unrollbits = True
 triggerFlagsAna.saveIsUnprescaled = True
 triggerFlagsAna.checkL1Prescale = True
 
-from CMGTools.RootTools.samples.samples_13TeV_RunIISpring16MiniAODv2 import *
+from CMGTools.RootTools.samples.samples_13TeV_RunIISummer16MiniAODv2 import *
 from CMGTools.RootTools.samples.samples_13TeV_DATA2016 import *
 from CMGTools.HToZZ4L.tools.configTools import printSummary, configureSplittingFromTime, cropToLumi, prescaleComponents, insertEventSelector
+from CMGTools.RootTools.samples.autoAAAconfig import *
 
 selectedComponents = [ DYJetsToLL_M50 ]
 
 samples_1fake = [QCD_Mu15] + QCD_Mu5 + QCDPtEMEnriched + QCDPtbcToE + GJetsDR04HT
-samples_WZ = [WJetsToLNu_LO, WJetsToLNu, DYJetsToLL_M50, DYJetsToLL_M50_LO, ZToMuMu_pow, ZToEE_pow]
-samples_BKG = [TTJets_SingleLeptonFromTbar, TTJets_SingleLeptonFromT, TBar_tWch, T_tWch, TToLeptons_sch_amcatnlo, TToLeptons_tch_amcatnlo, WW, WZ, ZZ]
+single_t = [TToLeptons_sch_amcatnlo,T_tch_powheg,TBar_tch_powheg,T_tWch_ext,TBar_tWch_ext] # single top + tW
+tt_1l = [TTJets_SingleLeptonFromT,TTJets_SingleLeptonFromT_ext,TTJets_SingleLeptonFromTbar,TTJets_SingleLeptonFromTbar_ext] # TT 1l
+v_jets = [WJetsToLNu_LO,WJetsToLNu_LO_ext,WJetsToLNu,DYJetsToLL_M50_LO_ext,DYJetsToLL_M50_LO_ext2,DYJetsToLL_M50] # V+jets
+dibosons = [WW,WW_ext,WZ,WZ_ext,ZZ,ZZ_ext] # di-boson
 
-selectedComponents = samples_1fake
+samples_1prompt = single_t + tt_1l + v_jets + dibosons
 
 for comp in selectedComponents: comp.splitFactor = 200
-configureSplittingFromTime(samples_1fake,50,3)
-configureSplittingFromTime(samples_WZ,100,3)
-configureSplittingFromTime(samples_BKG,100,3)
+configureSplittingFromTime(samples_1fake,30,6)
+configureSplittingFromTime(samples_1prompt,50,6)
 
 if scaleProdToLumi>0: # select only a subset of a sample, corresponding to a given luminosity (assuming ~30k events per MiniAOD file, which is ok for central production)
     target_lumi = scaleProdToLumi # in inverse picobarns
@@ -254,7 +238,7 @@ if runData and not isTest: # For running on data
 
     json = '/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt' # 36.5/fb
 
-    run_ranges = []; useAAA=True;
+    run_ranges = []; useAAA=False;
     processing = "Run2016B-18Apr2017_ver2-v1"; short = "Run2016B"; dataChunks.append((json,processing,short,run_ranges,useAAA))
     for era in 'CDEFGH':
         processing = "Run2016%s-18Apr2017-v1" % era; short = "Run2016%s" % era; dataChunks.append((json,processing,short,run_ranges,useAAA))
@@ -278,14 +262,6 @@ if runData and not isTest: # For running on data
             #("JetHT",   triggers_FR_jet )
         ]
         exclusiveDatasets = False
-    if runDataQCD and runQCDBM: # for fake rate measurements in data
-        FRTrigs_mu = triggers_FR_1mu_iso + triggers_FR_1mu_noiso
-        FRTrigs_el = triggers_FR_1e_noiso + triggers_FR_1e_iso + triggers_FR_1e_b2g
-        DatasetsAndTriggers = [
-            ("SingleMuon", triggers_FR_muNoIso ),
-            ("DoubleMuon",  triggers_FR_1mu_noiso ),
-        ]
-        exclusiveDatasets = True
 
     if runDataQCD: # for fake rate measurements in data
         ttHLepSkim.minLeptons = 1
@@ -326,12 +302,15 @@ if runData and not isTest: # For running on data
                     from CMGTools.Production.promptRecoRunRangeFilter import filterComponent
                     filterComponent(comp, verbose=1)
                 print "Will process %s (%d files)" % (comp.name, len(comp.files))
+                comp.splitFactor = len(comp.files)/8 if 'Single' not in comp.name else len(comp.files)/16
                 comp.splitFactor = len(comp.files)/8
                 comp.fineSplitFactor = 1
                 selectedComponents.append( comp )
             if exclusiveDatasets: vetos += triggers
     if json is None:
-        susyCoreSequence.remove(jsonAna)
+        dmCoreSequence.remove(jsonAna)
+    if runDataQCD: # for fake rate measurements in data
+         configureSplittingFromTime(selectedComponents, 3.5, 2, maxFiles=15)
 
 if True:
     from CMGTools.Production.promptRecoRunRangeFilter import filterComponent
@@ -345,32 +324,23 @@ if True:
 
 
 if runFRMC: 
-    QCD_Mu5 = [ QCD_Pt20to30_Mu5, QCD_Pt30to50_Mu5, QCD_Pt50to80_Mu5, QCD_Pt80to120_Mu5, QCD_Pt120to170_Mu5 ]
-#    QCDPtEMEnriched = [ QCD_Pt20to30_EMEnriched, QCD_Pt30to50_EMEnriched, QCD_Pt50to80_EMEnriched, QCD_Pt80to120_EMEnriched, QCD_Pt120to170_EMEnriched ]
-#    QCDPtbcToE = [ QCD_Pt_20to30_bcToE, QCD_Pt_30to80_bcToE, QCD_Pt_80to170_bcToE ]
-#    QCDHT = [ QCD_HT100to200, QCD_HT200to300, QCD_HT300to500, QCD_HT500to700 ]
-#    selectedComponents = [QCD_Mu15] + QCD_Mu5 + QCDPtEMEnriched + QCDPtbcToE + [WJetsToLNu_LO,DYJetsToLL_M10to50,DYJetsToLL_M50]
-#    selectedComponents = [ QCD_Pt_170to250_bcToE, QCD_Pt120to170_EMEnriched, QCD_Pt170to300_EMEnriched ]
-#    selectedComponents = [QCD_Mu15]
-
-#    selectedComponents = [TTJets_SingleLeptonFromT,TTJets_SingleLeptonFromTbar]
-
-    selectedComponents = [QCD_Mu15] + QCD_Mu5 + [WJetsToLNu,DYJetsToLL_M10to50,DYJetsToLL_M50] 
-
-    time = 5.0
-    configureSplittingFromTime([WJetsToLNu],20,time)
-#    configureSplittingFromTime([WJetsToLNu_LO],20,time)
-    configureSplittingFromTime([DYJetsToLL_M10to50],10,time)
-    configureSplittingFromTime([DYJetsToLL_M50],30,time)
-    configureSplittingFromTime([QCD_Mu15]+QCD_Mu5,70,time)
-#    configureSplittingFromTime(QCDPtbcToE,50,time)
-#    configureSplittingFromTime(QCDPtEMEnriched,25,time)
-#    configureSplittingFromTime([ QCD_HT100to200, QCD_HT200to300 ],10,time)
-#    configureSplittingFromTime([ QCD_HT300to500, QCD_HT500to700 ],15,time)
-#    configureSplittingFromTime([ QCD_Pt120to170_EMEnriched,QCD_Pt170to300_EMEnriched ], 15, time)
-#    configureSplittingFromTime([ QCD_Pt_170to250_bcToE ], 30, time)
-    if runQCDBM:
-        configureSplittingFromTime([QCD_Mu15]+QCD_Mu5,15,time)
+    QCD_Mu5 = [ QCD_Pt20to30_Mu5, QCD_Pt30to50_Mu5, QCD_Pt50to80_Mu5, QCD_Pt80to120_Mu5, QCD_Pt120to170_Mu5, QCD_Pt170to300_Mu5 ]
+    autoAAA(QCDPtEMEnriched+QCDPtbcToE)
+    QCDEm, _ = mergeExtensions([q for q in QCDPtEMEnriched+QCDPtbcToE if "toInf" not in q.name])
+    selectedComponents = [QCD_Mu15] + QCD_Mu5 + [WJetsToLNu_LO,DYJetsToLL_M10to50_LO,DYJetsToLL_M50_LO_ext] + QCDEm
+    selectedComponents = [TTJets_DiLepton]#TTJets_SingleLeptonFromT,TTJets_SingleLeptonFromTbar]
+    selectedComponents = [TBar_tWch_noFullyHad,T_tWch_noFullyHad]
+    TTJets_DiLepton.fineSplitFactor = 2
+    #selectedComponents = TT_pow 
+    cropToLumi(selectedComponents, 1.0)
+    time = 5.0; extra = dict(maxFiles=10)
+    configureSplittingFromTime([WJetsToLNu_LO],20,time, **extra)
+    configureSplittingFromTime([DYJetsToLL_M10to50_LO],10,time, **extra)
+    configureSplittingFromTime([DYJetsToLL_M50_LO_ext],40,time, **extra)
+    configureSplittingFromTime([QCD_Mu15]+QCD_Mu5,40,time, **extra)
+    configureSplittingFromTime(QCDEm, 40, time, **extra)
+    #configureSplittingFromTime([ QCD_HT100to200, QCD_HT200to300 ],10,time, **extra)
+    #configureSplittingFromTime([ QCD_HT300to500, QCD_HT500to700 ],15,time, **extra)
     for c in selectedComponents:
         c.triggers = []
         c.vetoTriggers = [] 
@@ -378,13 +348,11 @@ if runFRMC:
 
 if runFRMC or runDataQCD:
     ttHLepSkim.minLeptons = 1
-    if ttHJetMETSkim in susyCoreSequence: susyCoreSequence.remove(ttHJetMETSkim)
     if getHeppyOption("fast"): raise RuntimeError, 'Already added ttHFastLepSkimmer with 2-lep configuration, this is wrong.'
-    if runDataQCD:
-        FRTrigs = triggers_FR_1mu_iso + triggers_FR_1mu_noiso + triggers_FR_1e_noiso + triggers_FR_1e_iso + triggers_FR_1e_b2g + triggers_FR_jet + triggers_FR_muNoIso
-        for t in FRTrigs:
-            tShort = t.replace("HLT_","FR_").replace("_v*","")
-            triggerFlagsAna.triggerBits[tShort] = [ t ]
+    FRTrigs = triggers_FR_1mu_iso + triggers_FR_1mu_noiso + triggers_FR_1e_noiso + triggers_FR_1e_iso + triggers_FR_1e_b2g + triggers_FR_jet + triggers_FR_muNoIso
+    for t in FRTrigs:
+        tShort = t.replace("HLT_","FR_").replace("_v*","")
+        triggerFlagsAna.triggerBits[tShort] = [ t ]
     treeProducer.collections = {
         "selectedLeptons" : NTupleCollection("LepGood",  leptonTypeSusyExtraLight, 8, help="Leptons after the preselection"),
         "cleanJets"       : NTupleCollection("Jet",     jetTypeSusyExtraLight, 15, help="Cental jets after full selection and cleaning, sorted by pt"),
@@ -392,10 +360,11 @@ if runFRMC or runDataQCD:
     if True: # 
         from CMGTools.TTHAnalysis.analyzers.ttHLepQCDFakeRateAnalyzer import ttHLepQCDFakeRateAnalyzer
         ttHLepQCDFakeRateAna = cfg.Analyzer(ttHLepQCDFakeRateAnalyzer, name="ttHLepQCDFakeRateAna",
-            jetSel = lambda jet : jet.pt() > (25 if abs(jet.eta()) < 2.4 else 30),
+            #jetSel = lambda jet : jet.pt() > (25 if abs(jet.eta()) < 2.4 else 30),
+            jetSel = lambda jet : jet.pt() > 30 and abs(jet.eta()) < 2.4,
             pairSel = lambda lep, jet: deltaR(lep.eta(),lep.phi(), jet.eta(), jet.phi()) > 0.7,
         )
-        susyCoreSequence.insert(susyCoreSequence.index(jetAna)+1, ttHLepQCDFakeRateAna)
+        dmCoreSequence.insert(dmCoreSequence.index(jetAna)+1, ttHLepQCDFakeRateAna)
         leptonTypeSusyExtraLight.addVariables([
             NTupleVariable("awayJet_pt", lambda x: x.awayJet.pt() if x.awayJet else 0, help="pT of away jet"),
             NTupleVariable("awayJet_eta", lambda x: x.awayJet.eta() if x.awayJet else 0, help="eta of away jet"),
@@ -413,35 +382,10 @@ if runFRMC or runDataQCD:
             electrons = 'slimmedElectrons', eleCut = lambda ele : ele.pt() > 5,
             minLeptons = 1,
         )
-        susyCoreSequence.insert(susyCoreSequence.index(jsonAna)+1, fastSkim)
-        susyCoreSequence.remove(lheWeightAna)
-        susyCounter.doLHE = False
-    if runQCDBM:
-        fastSkimBM = cfg.Analyzer(
-            ttHFastLepSkimmer, name="ttHFastLepSkimmerBM",
-            muons = 'slimmedMuons', muCut = lambda mu : mu.pt() > 8,
-            electrons = 'slimmedElectrons', eleCut = lambda ele : False,
-            minLeptons = 1,
-        )
-        fastSkim.minLeptons = 2
-        ttHLepSkim.maxLeptons = 1
-        susyCoreSequence.insert(susyCoreSequence.index(skimAnalyzer)+1, fastSkimBM)
-        from PhysicsTools.Heppy.analyzers.core.TriggerMatchAnalyzer import TriggerMatchAnalyzer
-        trigMatcher1Mu2J = cfg.Analyzer(
-            TriggerMatchAnalyzer, name="trigMatcher1Mu",
-            label='1Mu',
-            processName = 'PAT',
-            fallbackProcessName = 'RECO',
-            unpackPathNames = True,
-            trgObjSelectors = [ lambda t : t.path("HLT_Mu8_v*",1,0) or t.path("HLT_Mu17_v*",1,0) or t.path("HLT_Mu22_v*",1,0) or t.path("HLT_Mu27_v*",1,0) or t.path("HLT_Mu45_eta2p1_v*",1,0) or t.path("HLT_L2Mu10_v*",1,0) ],
-            collToMatch = 'cleanJetsAll',
-            collMatchSelectors = [ lambda l,t : True ],
-            collMatchDRCut = 0.4,
-            univoqueMatching = True,
-            verbose = False,
-            )
-        susyCoreSequence.insert(susyCoreSequence.index(jetAna)+1, trigMatcher1Mu2J)
-        ttHLepQCDFakeRateAna.jetSel = lambda jet : jet.pt() > 25 and abs(jet.eta()) < 2.4 and jet.matchedTrgObj1Mu
+        dmCoreSequence.insert(dmCoreSequence.index(jsonAna)+1, fastSkim)
+        dmCoreSequence.remove(lheWeightAna)
+        histoCounter.doLHE = False
+
 
 if removeJetReCalibration:
     jetAna.recalibrateJets = False
@@ -464,12 +408,11 @@ if selectedEvents!="":
         EventSelector,'EventSelector',
         toSelect = events
         )
-    susyCoreSequence.insert(susyCoreSequence.index(lheWeightAna), eventSelector)
+    dmCoreSequence.insert(dmCoreSequence.index(lheWeightAna), eventSelector)
 
 #-------- SEQUENCE -----------
 
-sequence = cfg.Sequence(susyCoreSequence+[
-        ttHJetTauAna,
+sequence = cfg.Sequence(dmCoreSequence+[
         ttHEventAna,
         treeProducer,
     ])
@@ -480,14 +423,21 @@ preprocessor = None
 test = getHeppyOption('test')
 if test == '1':
     comp = selectedComponents[0]
-    comp.files = comp.files[:1]
+    if getHeppyOption('manyfiles'):
+        filesPerJob = max(len(comp.files)/comp.splitFactor, 1)
+        comp.files = comp.files[:filesPerJob]
+    else:
+        #comp.files = comp.files[:1]
+        comp.files = comp.files[8:9]
     comp.splitFactor = 1
     comp.fineSplitFactor = 1
     selectedComponents = [ comp ]
 elif test == '2':
-    from CMGTools.Production.promptRecoRunRangeFilter import filterWithCollection
-    for comp in selectedComponents:
-        if comp.isData: comp.files = filterWithCollection(comp.files, [274315,275658,276363,276454])
+    sel = getHeppyOption('sel','.*')
+    for comp in selectedComponents[:]:
+        if sel and not any(re.search(p.strip(),comp.name) for p in sel.split(",")):
+            selectedComponents.remove(comp)
+            continue
         comp.files = comp.files[:1]
         comp.splitFactor = 1
         comp.fineSplitFactor = 1
@@ -501,23 +451,20 @@ elif test == '5':
         comp.files = comp.files[:5]
         comp.splitFactor = 1
         comp.fineSplitFactor = 5
-elif test == "tau-sync":
-    comp = cfg.MCComponent( files = [ "root://eoscms.cern.ch//store/mc/RunIISpring16MiniAODv2/TTWJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/MINIAODSIM/PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/50000/8E84F4BB-B620-E611-BBD8-B083FECFF2BF.root"], name="TTW_Tau" )
-    comp.triggers = []
-    comp.splitFactor = 1
-    comp.fineSplitFactor = 6
-    selectedComponents = [ comp ]
-    sequence.remove(jsonAna)
-    ttHLepSkim.minLeptons = 0
+elif test == '21':
+    for comp in selectedComponents:
+        comp.files = comp.files[:7]
+        comp.splitFactor = 1
+        comp.fineSplitFactor = 3
 elif test == '80X-MC':
     what = getHeppyOption("sample","DYLL")
     if what == "DYLL":
-        DYJetsToLL_M50 = kreator.makeMCComponent("DYJetsToLL_M50", "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM", "CMS", ".*root", 2008.*3)
+        DYJetsToLL_M50 = kreator.makeMCComponent("DYJetsToLL_M50", "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v2/MINIAODSIM", "CMS", ".*root", 2008.*3)
         selectedComponents = [ DYJetsToLL_M50 ]
         comp = selectedComponents[0]
         comp.triggers = []
-        comp.files = [ '/store/mc/RunIISpring16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/50000/F6593370-9F2A-E611-A722-0CC47A78A4A6.root' ]
-        tmpfil = os.path.expandvars("/tmp/$USER/F6593370-9F2A-E611-A722-0CC47A78A4A6.root")
+        comp.files = [ '/store/mc/RunIISummer16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v2/120000/101D622A-85C4-E611-A7C2-C4346BC80410.root' ]
+        tmpfil = os.path.expandvars("/tmp/$USER/101D622A-85C4-E611-A7C2-C4346BC80410.root")
         if not os.path.exists(tmpfil):
             os.system("xrdcp root://eoscms//eos/cms%s %s" % (comp.files[0],tmpfil))
         comp.files = [ tmpfil ]
@@ -527,8 +474,8 @@ elif test == '80X-MC':
 elif test == '80X-Data':
     DoubleMuon = kreator.makeDataComponent("DoubleMuon_Run2016B_run274315", "/DoubleMuon/Run2016B-18Apr2017_ver2-v1/MINIAOD", "CMS", ".*root", run_range = (274315,274315), triggers = triggers_mumu)
     DoubleEG = kreator.makeDataComponent("DoubleEG_Run2016B_run274315", "/DoubleEG/Run2016B-18Apr2017_ver2-v1/MINIAOD", "CMS", ".*root", run_range = (274315,274315), triggers = triggers_ee)
-    DoubleMuon.files = [ 'root://xrootd-cms.infn.it//store/data/Run2016B/DoubleMuon/MINIAOD/18Apr2017_ver2-v1/120000/5A3F07DC-8D34-E711-8E2E-1866DAEB528C.root' ]
-    DoubleEG.files = [ 'root://xrootd-cms.infn.it//store/data/Run2016B/DoubleEG/MINIAOD/18Apr2017_ver2-v1/00000/84E8D574-F93D-E711-AD25-0242AC130006.root' ]
+    DoubleMuon.files = [ 'root://xrootd-cms.infn.it//store/data/Run2016B/DoubleMuon/MINIAOD/18Apr2017_ver2-v1/100000/DA4A8A8A-7436-E711-BDB1-24BE05C6D731.root' ]
+    DoubleEG.files = [ 'root://xrootd-cms.infn.it//store/data/Run2016B/DoubleEG/MINIAOD/18Apr2017_ver2-v1/00000/689FEB7E-DE3E-E711-8815-001E67A41EA0.root' ]
     selectedComponents = [ DoubleMuon, DoubleEG ]
     for comp in selectedComponents:
         comp.json = '/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt'
@@ -537,23 +484,13 @@ elif test == '80X-Data':
         comp.files = [tmpfil]
         comp.splitFactor = 1
         comp.fineSplitFactor = 1
-elif test == 'ttH-sync':
-    ttHLepSkim.minLeptons=0
-    selectedComponents = selectedComponents[:1]
-    comp = selectedComponents[0]
-    comp.files = ['/store/mc/RunIIFall15MiniAODv2/ttHToNonbb_M125_13TeV_powheg_pythia8/MINIAODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/00000/021B993B-4DBB-E511-BBA6-008CFA1111B4.root']
-    tmpfil = os.path.expandvars("/tmp/$USER/021B993B-4DBB-E511-BBA6-008CFA1111B4.root")
-    if not os.path.exists(tmpfil):
-        os.system("xrdcp root://eoscms//eos/cms%s %s" % (comp.files[0],tmpfil))
-    comp.files = [ tmpfil ]
-    if not getHeppyOption("single"): comp.fineSplitFactor = 8
 elif test != None:
     raise RuntimeError, "Unknown test %r" % test
 
 ## FAST mode: pre-skim using reco leptons, don't do accounting of LHE weights (slow)"
 ## Useful for large background samples with low skim efficiency
 if getHeppyOption("fast"):
-    susyCounter.doLHE = False
+    histoCounter.doLHE = False
     from CMGTools.TTHAnalysis.analyzers.ttHFastLepSkimmer import ttHFastLepSkimmer
     fastSkim = cfg.Analyzer(
         ttHFastLepSkimmer, name="ttHFastLepSkimmer1lep",
@@ -568,10 +505,9 @@ if getHeppyOption("fast"):
 if not getHeppyOption("keepLHEweights",False):
     if "LHE_weights" in treeProducer.collections: treeProducer.collections.pop("LHE_weights")
     if lheWeightAna in sequence: sequence.remove(lheWeightAna)
-    susyCounter.doLHE = False
+    histoCounter.doLHE = False
 
 ## Auto-AAA
-from CMGTools.RootTools.samples.autoAAAconfig import *
 if not getHeppyOption("isCrab"):
     autoAAA(selectedComponents)
 

--- a/MonoXAnalysis/python/analyzers/dmCore_modules_cff.py
+++ b/MonoXAnalysis/python/analyzers/dmCore_modules_cff.py
@@ -147,6 +147,7 @@ genAna = cfg.Analyzer(
     # Make also the splitted lists
     makeSplittedGenLists = True,
     allGenTaus = False,
+    saveIncomingPartons = True,
     # Print out debug information
     verbose = False,
     )

--- a/MonoXAnalysis/python/analyzers/dmCore_modules_cff.py
+++ b/MonoXAnalysis/python/analyzers/dmCore_modules_cff.py
@@ -10,7 +10,7 @@ from PhysicsTools.Heppy.analyzers.gen.all import *
 import os
 
 from CMGTools.TTHAnalysis.analyzers.ttHhistoCounterAnalyzer import ttHhistoCounterAnalyzer
-dmCounter = cfg.Analyzer(
+histoCounter = cfg.Analyzer(
     ttHhistoCounterAnalyzer, name="ttHhistoCounterAnalyzer",
     )
 
@@ -43,6 +43,7 @@ triggerAna = cfg.Analyzer(
 triggerFlagsAna = cfg.Analyzer(
     TriggerBitAnalyzer, name="TriggerFlags",
     processName = 'HLT',
+    fallbackProcessName = 'HLT2',
     prescaleProcessName = 'PAT',
     prescaleFallbackProcessName = 'RECO',
     unrollbits = False,
@@ -54,6 +55,33 @@ triggerFlagsAna = cfg.Analyzer(
     )
 
 # Create flags for MET filter bits
+eventFlagsAna = cfg.Analyzer(
+    TriggerBitAnalyzer, name="EventFlags",
+    processName = 'PAT',
+    fallbackProcessName = 'RECO',
+    outprefix   = 'Flag',
+    triggerBits = {
+        "HBHENoiseFilter" : [ "Flag_HBHENoiseFilter" ],
+        "HBHENoiseIsoFilter" : [ "Flag_HBHENoiseIsoFilter" ],
+        "globalTightHalo2016Filter" : [ "Flag_globalTightHalo2016Filter" ],
+        "CSCTightHalo2015Filter" : [ "Flag_CSCTightHalo2015Filter" ],
+        "CSCTightHaloFilter" : [ "Flag_CSCTightHaloFilter" ],
+        "CSCTightHalo2016Filter" : [ "Flag_globalTightHalo2016Filter" ],
+        "hcalLaserEventFilter" : [ "Flag_hcalLaserEventFilter" ],
+        "EcalDeadCellTriggerPrimitiveFilter" : [ "Flag_EcalDeadCellTriggerPrimitiveFilter" ],
+        "goodVertices" : [ "Flag_goodVertices" ],
+        "trackingFailureFilter" : [ "Flag_trackingFailureFilter" ],
+        "eeBadScFilter" : [ "Flag_eeBadScFilter" ],
+        "ecalLaserCorrFilter" : [ "Flag_ecalLaserCorrFilter" ],
+        "trkPOGFilters" : [ "Flag_trkPOGFilters" ],
+        "trkPOG_manystripclus53X" : [ "Flag_trkPOG_manystripclus53X" ],
+        "trkPOG_toomanystripclus53X" : [ "Flag_trkPOG_toomanystripclus53X" ],
+        "trkPOG_logErrorTooManyClusters" : [ "Flag_trkPOG_logErrorTooManyClusters" ],
+        "MuFlag_good" : [ "Flag_noBadMuons" ],
+        "MuFlag_bad" : [ "Flag_badMuons" ],
+        "MuFlag_dup" : [ "Flag_duplicateMuons" ],
+    }
+    )
 
 from CMGTools.TTHAnalysis.analyzers.badChargedHadronAnalyzer import badChargedHadronAnalyzer
 badChargedHadronAna = cfg.Analyzer(
@@ -69,30 +97,24 @@ badMuonAna = cfg.Analyzer(
     packedCandidates = 'packedPFCandidates',
 )
 
-eventFlagsAna = cfg.Analyzer(
-    TriggerBitAnalyzer, name="EventFlags",
-    processName = 'PAT',
-    fallbackProcessName = 'RECO',
-    outprefix   = 'Flag',
-    triggerBits = {
-        "HBHENoiseFilter" : [ "Flag_HBHENoiseFilter" ],
-        "HBHENoiseIsoFilter" : [ "Flag_HBHENoiseIsoFilter" ],
-        "CSCTightHaloFilter" : [ "Flag_CSCTightHaloFilter" ],
-        "CSCTightHalo2015Filter" : [ "Flag_CSCTightHalo2015Filter" ],
-        "globalTightHalo2016Filter" : [ "Flag_globalTightHalo2016Filter" ],
-        "hcalLaserEventFilter" : [ "Flag_hcalLaserEventFilter" ],
-        "EcalDeadCellTriggerPrimitiveFilter" : [ "Flag_EcalDeadCellTriggerPrimitiveFilter" ],
-        "goodVertices" : [ "Flag_goodVertices" ],
-        "trackingFailureFilter" : [ "Flag_trackingFailureFilter" ],
-        "eeBadScFilter" : [ "Flag_eeBadScFilter" ],
-        "ecalLaserCorrFilter" : [ "Flag_ecalLaserCorrFilter" ],
-        "trkPOGFilters" : [ "Flag_trkPOGFilters" ],
-        "trkPOG_manystripclus53X" : [ "Flag_trkPOG_manystripclus53X" ],
-        "trkPOG_toomanystripclus53X" : [ "Flag_trkPOG_toomanystripclus53X" ],
-        "trkPOG_logErrorTooManyClusters" : [ "Flag_trkPOG_logErrorTooManyClusters" ],
-        "METFilters" : [ "Flag_METFilters" ],
-    }
-    )
+from CMGTools.TTHAnalysis.analyzers.badMuonAnalyzerMoriond2017 import badMuonAnalyzerMoriond2017
+badCloneMuonAnaMoriond2017 = cfg.Analyzer(
+    badMuonAnalyzerMoriond2017, name = 'badCloneMuonMoriond2017',
+    muons = 'slimmedMuons',
+    vertices         = 'offlineSlimmedPrimaryVertices',
+    minMuPt = 20,
+    selectClones = True,
+    postFix = '',
+)
+
+badMuonAnaMoriond2017 = cfg.Analyzer(
+    badMuonAnalyzerMoriond2017, name = 'badMuonMoriond2017',
+    muons = 'slimmedMuons',
+    vertices         = 'offlineSlimmedPrimaryVertices',
+    minMuPt = 20,
+    selectClones = False,
+    postFix = '',
+)
 
 # Select a list of good primary vertices (generic)
 vertexAna = cfg.Analyzer(
@@ -119,7 +141,7 @@ genAna = cfg.Analyzer(
     # Particles of which we want to save the pre-FSR momentum (a la status 3).
     # Note that for quarks and gluons the post-FSR doesn't make sense,
     # so those should always be in the list
-    savePreFSRParticleIds = [ 1,2,3,4,5, 11,12,13,14,15,16, 21 ],
+    savePreFSRParticleIds = [ 1,2,3,4,5, 11,12,13,14,15,16, 21,22 ],
     # Make also the list of all genParticles, for other analyzers to handle
     makeAllGenParticles = True,
     # Make also the splitted lists
@@ -156,15 +178,15 @@ lepAna = cfg.Analyzer(
     # input collections
     muons='slimmedMuons',
     electrons='slimmedElectrons',
-    rhoMuon= 'fixedGridRhoFastjetAll',
-    rhoElectron = 'fixedGridRhoFastjetAll',
+    rhoMuon= 'fixedGridRhoFastjetCentralNeutral',
+    rhoElectron = 'fixedGridRhoFastjetCentralNeutral',
     # energy scale corrections and ghost muon suppression (off by default)
     doMuonScaleCorrections=False,
     doElectronScaleCorrections=False, # "embedded" in 5.18 for regression
     doSegmentBasedMuonCleaning=False,
     # inclusive very loose muon selection
     inclusive_muon_id  = "POG_ID_Loose",
-    inclusive_muon_pt  = 3,
+    inclusive_muon_pt  = 7,
     inclusive_muon_eta = 2.4,
     inclusive_muon_dxy = 1000,
     inclusive_muon_dz  = 1000,
@@ -175,8 +197,7 @@ lepAna = cfg.Analyzer(
     loose_muon_eta    = 2.4,
     loose_muon_dxy    = 1000,
     loose_muon_dz     = 1000,
-    loose_muon_isoCut = (lambda mu : ( mu.relIso04 <= 0.4)), # this is not to apply loose_muon_relIso which is on DR=0.3
-    loose_muon_relIso = 0.4,
+    loose_muon_relIso = 1000,
     # inclusive very loose electron selection
     inclusive_electron_id  = "",
     inclusive_electron_pt  = 5,
@@ -208,50 +229,21 @@ lepAna = cfg.Analyzer(
     min_dr_electron_muon = 0.05,
     # do MC matching 
     do_mc_match = True, # note: it will in any case try it only on MC, not on data
+    do_mc_match_photons = "all",
     match_inclusiveLeptons = False, # match to all inclusive leptons
     )
 
-
-## MET-based Skim
-from CMGTools.MonoXAnalysis.analyzers.monoJetSkimmer import monoJetSkimmer
-monoJetSkim = cfg.Analyzer(
-    monoJetSkimmer, name='monoJetSkimmer',
-    jets      = "cleanJetsAll", # jet collection to use
-    jetPtCuts = [],          # e.g. [60,40,30,20] to require at least four jets with pt > 60,40,30,20 
-    metCut = 0               # MET cut      
-    )
-
-## number of leptons Skim
-from CMGTools.MonoXAnalysis.analyzers.monoJetCtrlLepSkimmer import monoJetCtrlLepSkimmer
-monoJetCtrlLepSkim = cfg.Analyzer(
-    monoJetCtrlLepSkimmer, name='monoJetCtrlLepSkimmer',
+## Lepton-based Skim (generic, but requirements depend on the final state)
+from CMGTools.TTHAnalysis.analyzers.ttHLepSkimmer import ttHLepSkimmer
+ttHLepSkim = cfg.Analyzer(
+    ttHLepSkimmer, name='ttHLepSkimmer',
     minLeptons = 0,
     maxLeptons = 999,
     #idCut  = "lepton.relIso03 < 0.2" # can give a cut
-    idCut = 'lepton.muonID("POG_ID_Loose") if abs(lepton.pdgId())==13 else lepton.electronID("POG_Cuts_ID_SPRING16_25ns_v1_ConvVetoDxyDz_Veto")',
-    ptCuts = [10],                # can give a set of pt cuts on the leptons
-    )
-
-## number of FatJets (ak08) Skim
-from CMGTools.MonoXAnalysis.analyzers.monoJetCtrlFatJetSkimmer import monoJetCtrlFatJetSkimmer
-monoJetCtrlFatJetSkim = cfg.Analyzer(
-    monoJetCtrlFatJetSkimmer, name='monoJetCtrlFatJetSkimmer',
-    minFatJets = 0,
-    maxFatJets = 999,
-    idCut= '',
-    ptCuts     = [160],
-    )
-
-## gamma+jets Skim
-from CMGTools.MonoXAnalysis.analyzers.gammaJetCtrlSkimmer import gammaJetCtrlSkimmer
-gammaJetCtrlSkim = cfg.Analyzer(
-    gammaJetCtrlSkimmer, name='gammaJetCtrlSkimmer',
-    minPhotons = 0,
-    minJets = 0,
-    photonIdCut = 'photon.photonID("PhotonCutBasedIDLoose")',
-    photonPtCut = 150,
-    jetPtCut = 0,
-    )
+    #ptCuts = [20,10],                # can give a set of pt cuts on the leptons
+    requireSameSignPair = False,
+    allowLepTauComb = False
+)
 
 ## Photon Analyzer (generic)
 photonAna = cfg.Analyzer(
@@ -346,7 +338,7 @@ jetAna = cfg.Analyzer(
     copyJetsByValue = False,      #Whether or not to copy the input jets or to work with references (should be 'True' if JetAnalyzer is run more than once)
     genJetCol = 'slimmedGenJets',
     rho = ('fixedGridRhoFastjetAll','',''),
-    jetPt = 15.,
+    jetPt = 25.,
     jetEta = 4.7,
     jetEtaCentral = 2.5,
     cleanJetsFromLeptons = True,
@@ -370,7 +362,7 @@ jetAna = cfg.Analyzer(
     cleanJetsFromFirstPhoton = False,
     cleanJetsFromTaus = False,
     cleanJetsFromIsoTracks = False,
-    doQG = True,
+    doQG = False,
     do_mc_match = True,
     cleanGenJetsFromPhoton = False,
     collectionPostFix = "",
@@ -378,6 +370,26 @@ jetAna = cfg.Analyzer(
     calculateType1METCorrection  = False,
     type1METParams = { 'jetPtThreshold':15., 'skipEMfractionThreshold':0.9, 'skipMuons':True },
     storeLowPtJets = False,
+    )
+
+## Jets Analyzer (generic)
+jetAnaScaleUp = jetAna.clone(name='jetAnalyzerScaleUp',
+    copyJetsByValue = True,
+    jetCol = 'slimmedJets',
+    shiftJEC = +1, # set to +1 or -1 to apply +/-1 sigma shift to the nominal jet energies
+    collectionPostFix = "_jecUp",
+    calculateType1METCorrection  = True,
+    cleanSelectedLeptons = False,
+   )
+
+## Jets Analyzer (generic)
+jetAnaScaleDown = jetAna.clone(name='jetAnalyzerScaleDown',
+    copyJetsByValue = True,
+    jetCol = 'slimmedJets',
+    shiftJEC = -1, # set to +1 or -1 to apply +/-1 sigma shift to the nominal jet energies
+    collectionPostFix = "_jecDown",
+    calculateType1METCorrection  = True,
+    cleanSelectedLeptons = False,
     )
 
 
@@ -425,11 +437,15 @@ metAna = cfg.Analyzer(
     metCollection     = "slimmedMETs",
     noPUMetCollection = "slimmedMETs",
     copyMETsByValue = False,
-    doTkMet = False,
+    doTkMet = True,
+    includeTkMetCHS = True,
+    includeTkMetPVLoose = True,
+    includeTkMetPVTight = True,
     doMetNoPU = True,
-    doMetNoMu = True,
+    doMetNoMu = False,
     doMetNoEle = False,
     doMetNoPhoton = False,
+    storePuppiExtra = False, # False for MC, True for re-MiniAOD
     recalibrate = False,  # or "type1", or True 
     applyJetSmearing = False, # does nothing unless the jet smearing is turned on in the jet analyzer
     old74XMiniAODs = False, # set to True to get the correct Raw MET when running on old 74X MiniAODs
@@ -440,26 +456,19 @@ metAna = cfg.Analyzer(
     collectionPostFix = "",
     )
 
-metNoHFAna = cfg.Analyzer(
-    METAnalyzer, name="metNoHFAnalyzer",
-    metCollection     = "slimmedMETsNoHF",
-    noPUMetCollection = "slimmedMETsNoHF",
-    copyMETsByValue = False,
-    doTkMet = False,
-    doMetNoPU = True,
-    doMetNoMu = False,
-    doMetNoEle = False,
-    doMetNoPhoton = False,
-    recalibrate = False,
-    applyJetSmearing = False, # does nothing unless the jet smearing is turned on in the jet analyzer
-    old74XMiniAODs = False,   # can't be true, since MET NoHF wasn't there in old 74X MiniAODs
-    jetAnalyzerPostFix = "",
-    candidates='packedPFCandidates',
-    candidatesTypes='std::vector<pat::PackedCandidate>',
-    dzMax = 0.1,
-    collectionPostFix = "NoHF",
+metAnaScaleUp = metAna.clone(name="metAnalyzerScaleUp",
+    copyMETsByValue = True,
+    recalibrate = "type1", 
+    jetAnalyzerPostFix = "_jecUp",
+    collectionPostFix = "_jecUp",
     )
 
+metAnaScaleDown = metAna.clone(name="metAnalyzerScaleDown",
+    copyMETsByValue = True,
+    recalibrate = "type1", 
+    jetAnalyzerPostFix = "_jecDown",
+    collectionPostFix = "_jecDown",
+    )
 
 # Core Event Analyzer (computes basic quantities like HT, dilepton masses)
 from CMGTools.TTHAnalysis.analyzers.ttHCoreEventAnalyzer import ttHCoreEventAnalyzer
@@ -506,25 +515,26 @@ dmCoreSequence = [
     triggerAna,
     pileUpAna,
     genAna,
-    genHiggsAna,
-    genHFAna,
+#    genHiggsAna,
+#    genHFAna,
     pdfwAna,
     vertexAna,
     lepAna,
     jetAna,
-    monoJetCtrlLepSkim,
+    ttHLepSkim,
     metAna,
-    monoJetSkim,
     photonAna,
-    tauAna,
-    monoxTauAna,
-    isoTrackAna,
+#    tauAna,
+#    monoxTauAna,
+#    isoTrackAna,
     ttHCoreEventAna,
-    monoXFatJetAna,
-    monoJetCtrlFatJetSkim,
-    gammaJetCtrlSkim,
+#    monoXFatJetAna,
+#    monoJetCtrlFatJetSkim,
+#    gammaJetCtrlSkim,
     triggerFlagsAna,
-    badChargedHadronAna,
-    badMuonAna,
     eventFlagsAna,
+    badMuonAna,
+    badMuonAnaMoriond2017,
+    badCloneMuonAnaMoriond2017,
+    badChargedHadronAna,
 ]

--- a/MonoXAnalysis/python/analyzers/ntupleTypes.py
+++ b/MonoXAnalysis/python/analyzers/ntupleTypes.py
@@ -1,0 +1,37 @@
+#!/bin/env python
+from math import *
+from PhysicsTools.Heppy.analyzers.core.autovars import NTupleObjectType  
+from PhysicsTools.Heppy.analyzers.objects.autophobj import  *
+from PhysicsTools.HeppyCore.utils.deltar import deltaR
+
+from CMGTools.TTHAnalysis.signedSip import *
+from CMGTools.TTHAnalysis.tools.functionsTTH import _ttH_idEmu_cuts_E2_obj,_soft_MuonId_2016ICHEP,_medium_MuonId_2016ICHEP
+from CMGTools.TTHAnalysis.tools.functionsRAX import _susy2lss_idEmu_cuts_obj,_susy2lss_idIsoEmu_cuts_obj
+
+##------------------------------------------  
+## LEPTON
+##------------------------------------------  
+
+leptonTypeWMass = NTupleObjectType("leptonWMass", baseObjectTypes = [ leptonType ], variables = [
+    # Lepton MVA-id related variables
+    NTupleVariable("mvaTTH",    lambda lepton : getattr(lepton, 'mvaValueTTH', -1), help="Lepton MVA (TTH version)"),
+    NTupleVariable("mvaSUSY",    lambda lepton : getattr(lepton, 'mvaValueSUSY', -1), help="Lepton MVA (SUSY version)"),
+    NTupleVariable("jetDR",      lambda lepton : deltaR(lepton.eta(),lepton.phi(),lepton.jet.eta(),lepton.jet.phi()) if hasattr(lepton,'jet') else -1, help="deltaR(lepton, nearest jet)"),
+    NTupleVariable("r9",      lambda lepton : lepton.full5x5_r9() if abs(lepton.pdgId()) == 11 else -99, help="SuperCluster 5x5 r9 variable, only for electrons; -99 for muons"),
+    #2016 muon Id
+    NTupleVariable("softMuonId2016", lambda lepton: _soft_MuonId_2016ICHEP(lepton), help="Soft muon ID retuned for ICHEP 2016"),
+    NTupleVariable("mediumMuonID2016", lambda lepton: _medium_MuonId_2016ICHEP(lepton), help="Medium muon ID retuned for ICHEP 2016"),
+    # More
+    NTupleVariable("tightChargeFix",  lambda lepton : ( lepton.isGsfCtfScPixChargeConsistent() + lepton.isGsfScPixChargeConsistent() ) if abs(lepton.pdgId()) == 11 else 2*(lepton.muonBestTrack().ptError()/lepton.muonBestTrack().pt() < 0.2), int, help="Tight charge criteria: for electrons, 2 if isGsfCtfScPixChargeConsistent, 1 if only isGsfScPixChargeConsistent, 0 otherwise; for muons, 2 if ptError/pt < 0.20, 0 otherwise (using the muon best track)"),
+    NTupleVariable("muonTrackType",  lambda lepton : 1 if abs(lepton.pdgId()) == 11 else lepton.muonBestTrackType(), int, help="Muon best track type"),
+    NTupleVariable("chargeConsistency",  lambda lepton : ( lepton.isGsfCtfScPixChargeConsistent() + lepton.isGsfScPixChargeConsistent() ) if abs(lepton.pdgId()) == 11 else abs(lepton.muonBestTrack().charge() + lepton.innerTrack().charge() + lepton.tunePMuonBestTrack().charge() + ( lepton.globalTrack().charge() + lepton.outerTrack().charge() if lepton.isGlobalMuon() else 0) ), int, help="Tight charge criteria: for electrons, 2 if isGsfCtfScPixChargeConsistent, 1 if only isGsfScPixChargeConsistent, 0 otherwise; for muons, absolute value of the sum of all the charges (5 for global-muons, 3 for global muons)"),
+    NTupleVariable("ptErrTk",  lambda lepton : ( lepton.gsfTrack().ptError() ) if abs(lepton.pdgId()) == 11 else (lepton.muonBestTrack().ptError()), help="pt error, for the gsf track or muon best track"),
+    # variables for isolated electron trigger matching cuts
+    NTupleVariable("ecalPFClusterIso", lambda lepton :  lepton.ecalPFClusterIso() if abs(lepton.pdgId())==11 else -999, help="Electron ecalPFClusterIso"),
+    NTupleVariable("hcalPFClusterIso", lambda lepton :  lepton.hcalPFClusterIso() if abs(lepton.pdgId())==11 else -999, help="Electron hcalPFClusterIso"),
+    NTupleVariable("dr03TkSumPt", lambda lepton: lepton.dr03TkSumPt() if abs(lepton.pdgId())==11 else -999, help="Electron dr03TkSumPt isolation"),
+    NTupleVariable("trackIso", lambda lepton :  lepton.trackIso() if abs(lepton.pdgId())==11 else -999, help="Electron trackIso (in cone of 0.4)"),
+    NTupleVariable("etaSc", lambda x : x.superCluster().eta() if abs(x.pdgId())==11 else -100, help="Electron supercluster pseudorapidity"),
+    NTupleVariable("energySc", lambda x : x.superCluster().energy() if abs(x.pdgId())==11 else -100, help="Electron supercluster pseudorapidity"),
+
+])

--- a/MonoXAnalysis/python/analyzers/ntupleTypes.py
+++ b/MonoXAnalysis/python/analyzers/ntupleTypes.py
@@ -33,5 +33,8 @@ leptonTypeWMass = NTupleObjectType("leptonWMass", baseObjectTypes = [ leptonType
     NTupleVariable("trackIso", lambda lepton :  lepton.trackIso() if abs(lepton.pdgId())==11 else -999, help="Electron trackIso (in cone of 0.4)"),
     NTupleVariable("etaSc", lambda x : x.superCluster().eta() if abs(x.pdgId())==11 else -100, help="Electron supercluster pseudorapidity"),
     NTupleVariable("energySc", lambda x : x.superCluster().energy() if abs(x.pdgId())==11 else -100, help="Electron supercluster pseudorapidity"),
-
+    NTupleVariable("e5x5", lambda x: x.full5x5_e5x5() if (abs(x.pdgId())==11 and hasattr(x,"full5x5_e5x5")) else -999, help="Electron full5x5_e5x5"),
+    NTupleVariable("sigmaIetaIeta", lambda x: x.full5x5_sigmaIetaIeta() if (abs(x.pdgId())==11 and hasattr(x,"full5x5_sigmaIetaIeta")) else -999, help="Electron full5x5_sigmaIetaIeta"),
+    NTupleVariable("hcalOverEcal", lambda x: x.full5x5_hcalOverEcal() if (abs(x.pdgId())==11 and hasattr(x,"full5x5_hcalOverEcal")) else -999, help="Electron full5x5_hcalOverEcal"),
+    NTupleVariable("eSuperClusterOverP", lambda x: x.eSuperClusterOverP() if (abs(x.pdgId())==11 and hasattr(x,"eSuperClusterOverP")) else -999, help="Electron eSuperClusterOverP"),
 ])

--- a/MonoXAnalysis/python/analyzers/treeProducerWMass.py
+++ b/MonoXAnalysis/python/analyzers/treeProducerWMass.py
@@ -1,4 +1,7 @@
+from PhysicsTools.Heppy.analyzers.core.AutoFillTreeProducer  import * 
+
 from CMGTools.TTHAnalysis.analyzers.ntupleTypes import *
+from CMGTools.MonoXAnalysis.analyzers.ntupleTypes import *
 
 wmass_globalVariables = [
 
@@ -18,36 +21,31 @@ wmass_globalVariables = [
 
             ##--------------------------------------------------            
             NTupleVariable("mZ1", lambda ev : ev.bestZ1[0], help="Best m(ll) SF/OS"),
-            NTupleVariable("mZ1SFSS", lambda ev : ev.bestZ1sfss[0], help="Best m(ll) SF/SS"),
-            NTupleVariable("m2l", lambda ev: ev.m2l, help="m(ll)"),
-            ##--------------------------------------------------
-            NTupleVariable("mZ2", lambda ev : ev.bestZ2[3], help="m(ll) of second SF/OS pair, for ZZ reco."),
-            NTupleVariable("pt2l", lambda ev: ev.pt2l, help="p_{T}(ll)"),
-
-            NTupleVariable("Flag_badChargedHadronFilter", lambda ev: ev.badChargedHadron, help="bad charged hadron filter decision"),
-            NTupleVariable("Flag_badMuonFilter", lambda ev: ev.badMuon, help="bad muon filter decision"),
 ]
 
 wmass_globalObjects = {
-            "met" : NTupleObject("met", metType, help="PF E_{T}^{miss}, after type 1 corrections"),
-            #"metNoPU" : NTupleObject("metNoPU", fourVectorType, help="PF noPU E_{T}^{miss}"),
+            "met"   : NTupleObject("met", metType, help="PF E_{T}^{miss}, after type 1 corrections"),
+            "tkMet" : NTupleObject("tkMet", fourVectorType, help="PF E_{T}^{miss} from charged candidates with dz<0.1"),
+            "tkMetPVchs" : NTupleObject("tkMetPVchs", fourVectorType, help="PF E_{T}^{miss} from charged candidates with chs"),
+            "tkMetPVLoose" : NTupleObject("tkMetPVLoose", fourVectorType, help="PF E_{T}^{miss} from charged candidates with Loose chs"),
+            "tkMetPVTight" : NTupleObject("tkMetPVTight", fourVectorType, help="PF E_{T}^{miss} from charged candidates with Tight chs"),
 }
 
 wmass_collections = {
-            "selectedLeptons" : NTupleCollection("LepGood",  leptonTypeSusyExtraLight, 8, help="Leptons after the preselection"),
-            "otherLeptons"    : NTupleCollection("LepOther", leptonTypeSusy, 8, help="Leptons after the preselection"),
+            "selectedLeptons" : NTupleCollection("LepGood",  leptonTypeWMass, 8, help="Leptons after the preselection"),
+            #"otherLeptons"    : NTupleCollection("LepOther", leptonTypeSusy, 8, help="Leptons after the preselection"),
             ##------------------------------------------------
             "cleanJets"       : NTupleCollection("Jet",     jetTypeSusyExtraLight, 15, help="Cental jets after full selection and cleaning, sorted by pt"),
-            "cleanJetsFwd"    : NTupleCollection("JetFwd",  jetTypeSusy,  6, help="Forward jets after full selection and cleaning, sorted by pt"),            
+            #"cleanJetsFwd"    : NTupleCollection("JetFwd",  jetTypeSusy,  6, help="Forward jets after full selection and cleaning, sorted by pt"),            
             #"fatJets"         : NTupleCollection("FatJet",  fatJetType,  15, help="AK8 jets, sorted by pt"),
             ##------------------------------------------------
             #"ivf"       : NTupleCollection("SV",     svType, 20, help="SVs from IVF"),
             ##------------------------------------------------
             "LHE_weights"    : NTupleCollection("LHEweight",  weightsInfoType, 1000, mcOnly=True, help="LHE weight info"),
             ##------------------------------------------------
-            "genleps"         : NTupleCollection("genLep",     genParticleWithLinksType, 10, help="Generated leptons (e/mu) from W/Z decays"),                                                                                                
-            "gentauleps"      : NTupleCollection("genLepFromTau", genParticleWithLinksType, 10, help="Generated leptons (e/mu) from decays of taus from W/Z/h decays"),                                                                       
-            "gentaus"         : NTupleCollection("genTau",     genParticleWithLinksType, 10, help="Generated leptons (tau) from W/Z decays"),                            
-            "generatorSummary" : NTupleCollection("GenPart", genParticleWithLinksType, 100 , help="Hard scattering particles, with ancestry and links"),
+            #"genleps"         : NTupleCollection("genLep",     genParticleWithLinksType, 10, help="Generated leptons (e/mu) from W/Z decays"),                                                                                                
+            #"gentauleps"      : NTupleCollection("genLepFromTau", genParticleWithLinksType, 10, help="Generated leptons (e/mu) from decays of taus from W/Z/h decays"),                                                                       
+            #"gentaus"         : NTupleCollection("genTau",     genParticleWithLinksType, 10, help="Generated leptons (tau) from W/Z decays"),                            
+            "generatorSummary" : NTupleCollection("GenPart", genParticleWithLinksType, 20 , help="Hard scattering particles, with ancestry and links"),
 }
 

--- a/MonoXAnalysis/python/analyzers/treeProducerWMass.py
+++ b/MonoXAnalysis/python/analyzers/treeProducerWMass.py
@@ -25,7 +25,6 @@ wmass_globalVariables = [
 
 wmass_globalObjects = {
             "met"   : NTupleObject("met", metType, help="PF E_{T}^{miss}, after type 1 corrections"),
-            "tkMet" : NTupleObject("tkMet", fourVectorType, help="PF E_{T}^{miss} from charged candidates with dz<0.1"),
             "tkMetPVchs" : NTupleObject("tkMetPVchs", fourVectorType, help="PF E_{T}^{miss} from charged candidates with chs"),
             "tkMetPVLoose" : NTupleObject("tkMetPVLoose", fourVectorType, help="PF E_{T}^{miss} from charged candidates with Loose chs"),
             "tkMetPVTight" : NTupleObject("tkMetPVTight", fourVectorType, help="PF E_{T}^{miss} from charged candidates with Tight chs"),


### PR DESCRIPTION
- reduce the tree size (removed Taus, removed discarded leptons and jets)
- remove the split generator collections, add back the GenPart, having added the incoming partons from https://github.com/emanueledimarco/cmg-cmssw/pull/4
- remove unneeded analyzers to speed up code (tau analyzer, genHiggs ana, etc)
- add few more variables for electrons in case we need to debug the ID / scale
- use the Summer16 MC production, not Spring16
- update the skim: use 1 "loose" lepton. For electrons, this is updated to be the HLT safe ID (since we will use the SingleElectron triggers for the application region
- good leptons: now are the ones passing the Spring16 CutBased ID (Veto WP)