### PR TITLE
Fake rate trees

### DIFF
--- a/MonoXAnalysis/cfg/run_wmass_cfg.py
+++ b/MonoXAnalysis/cfg/run_wmass_cfg.py
@@ -12,7 +12,7 @@ from PhysicsTools.HeppyCore.framework.heppy_loop import getHeppyOption
 
 #-------- SET OPTIONS AND REDEFINE CONFIGURATIONS -----------
 
-runData = getHeppyOption("runData",False)
+runData = getHeppyOption("runData",True)
 runDataQCD = getHeppyOption("runDataQCD",False)
 runFRMC = getHeppyOption("runFRMC",False)
 scaleProdToLumi = float(getHeppyOption("scaleProdToLumi",-1)) # produce rough equivalent of X /pb for MC datasets
@@ -28,7 +28,7 @@ isTest = getHeppyOption("test",None) != None and not re.match("^\d+$",getHeppyOp
 selectedEvents=getHeppyOption("selectEvents","")
 
 # save LHE weights: very big! do only for needed MC samples
-runOnSignal = True
+runOnSignal = False
 keepLHEweights = False
 
 # Lepton Skimming
@@ -218,7 +218,7 @@ w_jets = [WJetsToLNu_LO,WJetsToLNu_LO_ext,WJetsToLNu] # W+jets
 z_jets = [DYJetsToLL_M50_LO_ext,DYJetsToLL_M50_LO_ext2,DYJetsToLL_M50] # Z+jets
 dibosons = [WW,WW_ext,WZ,WZ_ext,ZZ,ZZ_ext] # di-boson
 
-samples_signal = v_jets
+samples_signal = w_jets
 samples_1prompt = single_t + tt_1l + z_jets + dibosons
 
 for comp in selectedComponents: comp.splitFactor = 200
@@ -264,8 +264,8 @@ if runData and not isTest: # For running on data
     # DatasetsAndTriggers.append( ("DoubleMuon", triggers_mumu_iso + triggers_mumu_ss + triggers_mumu_ht + triggers_3mu + triggers_3mu_alt) )
     # DatasetsAndTriggers.append( ("DoubleEG",   triggers_ee + triggers_ee_ht + triggers_3e) )
     # DatasetsAndTriggers.append( ("MuonEG",     triggers_mue + triggers_mue_ht + triggers_2mu1e + triggers_2e1mu) )
-    # DatasetsAndTriggers.append( ("SingleMuon", triggers_1mu_iso + triggers_1mu_noniso) )
-    DatasetsAndTriggers.append( ("SingleElectron", triggers_1e) )
+    DatasetsAndTriggers.append( ("SingleMuon", triggers_1mu_iso + triggers_1mu_noniso) )
+    # DatasetsAndTriggers.append( ("SingleElectron", triggers_1e) )
 
     if runDataQCD: # for fake rate measurements in data
         FRTrigs_mu = triggers_FR_1mu_noiso
@@ -305,6 +305,7 @@ if runData and not isTest: # For running on data
                 if run_range!=None:
                     label = "_runs_%d_%d" % run_range if run_range[0] != run_range[1] else "run_%d" % (run_range[0],)
                 compname = pd+"_"+short+label
+                if pd=='SingleMuon' and 'Run2016F-18Apr2017-v1' in processing: processing='Run2016F-18Apr2017-v2'
                 comp = kreator.makeDataComponent(compname, 
                                                  "/"+pd+"/"+processing+"/MINIAOD",
                                                  "CMS", ".*root", 

--- a/MonoXAnalysis/cfg/run_wmass_cfg.py
+++ b/MonoXAnalysis/cfg/run_wmass_cfg.py
@@ -12,9 +12,9 @@ from PhysicsTools.HeppyCore.framework.heppy_loop import getHeppyOption
 
 #-------- SET OPTIONS AND REDEFINE CONFIGURATIONS -----------
 
-runData = getHeppyOption("runData",True)
+runData = getHeppyOption("runData",False)
 runDataQCD = getHeppyOption("runDataQCD",False)
-runFRMC = getHeppyOption("runFRMC",False)
+runFRMC = getHeppyOption("runFRMC",True)
 scaleProdToLumi = float(getHeppyOption("scaleProdToLumi",-1)) # produce rough equivalent of X /pb for MC datasets
 removeJetReCalibration = getHeppyOption("removeJetReCalibration",False)
 removeJecUncertainty = getHeppyOption("removeJecUncertainty",False)
@@ -206,7 +206,7 @@ triggerFlagsAna.checkL1Prescale = True
 
 from CMGTools.RootTools.samples.samples_13TeV_RunIISummer16MiniAODv2 import *
 from CMGTools.RootTools.samples.samples_13TeV_DATA2016 import *
-from CMGTools.HToZZ4L.tools.configTools import printSummary, configureSplittingFromTime, cropToLumi, prescaleComponents, insertEventSelector
+from CMGTools.HToZZ4L.tools.configTools import printSummary, configureSplittingFromTime, cropToLumi, prescaleComponents, insertEventSelector, mergeExtensions
 from CMGTools.RootTools.samples.autoAAAconfig import *
 
 selectedComponents = [ DYJetsToLL_M50 ]
@@ -343,9 +343,9 @@ if runFRMC:
     autoAAA(QCDPtEMEnriched+QCDPtbcToE)
     QCDEm, _ = mergeExtensions([q for q in QCDPtEMEnriched+QCDPtbcToE if "toInf" not in q.name])
     selectedComponents = [QCD_Mu15] + QCD_Mu5 + [WJetsToLNu_LO,DYJetsToLL_M10to50_LO,DYJetsToLL_M50_LO_ext] + QCDEm
-    selectedComponents = [TTJets_DiLepton]#TTJets_SingleLeptonFromT,TTJets_SingleLeptonFromTbar]
-    selectedComponents = [TBar_tWch_noFullyHad,T_tWch_noFullyHad]
-    TTJets_DiLepton.fineSplitFactor = 2
+    #selectedComponents = [TTJets_DiLepton]#TTJets_SingleLeptonFromT,TTJets_SingleLeptonFromTbar]
+    #selectedComponents = [TBar_tWch_noFullyHad,T_tWch_noFullyHad]
+    #TTJets_DiLepton.fineSplitFactor = 2
     #selectedComponents = TT_pow 
     cropToLumi(selectedComponents, 1.0)
     time = 5.0; extra = dict(maxFiles=10)
@@ -369,7 +369,7 @@ if runFRMC or runDataQCD:
         tShort = t.replace("HLT_","FR_").replace("_v*","")
         triggerFlagsAna.triggerBits[tShort] = [ t ]
     treeProducer.collections = {
-        "selectedLeptons" : NTupleCollection("LepGood",  leptonTypeSusyExtraLight, 8, help="Leptons after the preselection"),
+        "selectedLeptons" : NTupleCollection("LepGood",  leptonTypeWMass, 8, help="Leptons after the preselection"),
         "cleanJets"       : NTupleCollection("Jet",     jetTypeSusyExtraLight, 15, help="Cental jets after full selection and cleaning, sorted by pt"),
     }
     if True: # 
@@ -380,7 +380,7 @@ if runFRMC or runDataQCD:
             pairSel = lambda lep, jet: deltaR(lep.eta(),lep.phi(), jet.eta(), jet.phi()) > 0.7,
         )
         dmCoreSequence.insert(dmCoreSequence.index(jetAna)+1, ttHLepQCDFakeRateAna)
-        leptonTypeSusyExtraLight.addVariables([
+        leptonTypeWMass.addVariables([
             NTupleVariable("awayJet_pt", lambda x: x.awayJet.pt() if x.awayJet else 0, help="pT of away jet"),
             NTupleVariable("awayJet_eta", lambda x: x.awayJet.eta() if x.awayJet else 0, help="eta of away jet"),
             NTupleVariable("awayJet_phi", lambda x: x.awayJet.phi() if x.awayJet else 0, help="phi of away jet"),
@@ -393,8 +393,8 @@ if runFRMC or runDataQCD:
         from CMGTools.TTHAnalysis.analyzers.ttHFastLepSkimmer import ttHFastLepSkimmer
         fastSkim = cfg.Analyzer(
             ttHFastLepSkimmer, name="ttHFastLepSkimmer1lep",
-            muons = 'slimmedMuons', muCut = lambda mu : mu.pt() > 3 and mu.isLooseMuon(),
-            electrons = 'slimmedElectrons', eleCut = lambda ele : ele.pt() > 5,
+            muons = 'slimmedMuons', muCut = lambda mu : mu.pt() > 15 and mu.isLooseMuon(),
+            electrons = 'slimmedElectrons', eleCut = lambda ele : ele.pt() > 15,
             minLeptons = 1,
         )
         dmCoreSequence.insert(dmCoreSequence.index(jsonAna)+1, fastSkim)


### PR DESCRIPTION
Adjust selection for trees used for fake-rate measurement.
Skim is:

- at least 1 loose lepton (ele or mu)
- at least 1 jet with pt>30 GeV and |eta|<2.4
- at least one jet/lep pair with deltaR > 0.7
